### PR TITLE
IE 11 support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -115,15 +115,15 @@ export default function devalue(value: any) {
 				return `new ${type}([${Array.from(thing).map(stringify).join(',')}])`;
 
 			default:
-				const obj = `{${Object.keys(thing).map(key => `${safeKey(key)}:${stringify(thing[key])}`).join(',')}}`;
-				const proto = Object.getPrototypeOf(thing);
-				if (proto === null) {
-					return Object.keys(thing).length > 0
-						? `Object.assign(Object.create(null),${obj})`
-						: `Object.create(null)`;
+				if (Object.getPrototypeOf(thing) === null) {
+					if (Object.keys(thing).length === 0) {
+						return 'Object.create(null)';
+					}
+
+					return `Object.create(null,{${Object.keys(thing).map(key => `${safeKey(key)}:{writable:true,value:${stringify(thing[key])}}`).join(',')}})`;
 				}
 
-				return obj;
+				return `{${Object.keys(thing).map(key => `${safeKey(key)}:${stringify(thing[key])}`).join(',')}}`;
 		}
 	}
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -93,6 +93,8 @@ describe('devalue', () => {
 	describe('misc', () => {
 		test('Object without prototype', Object.create(null), 'Object.create(null)');
 
+		test('Object without prototype with values', Object.assign(Object.create(null), { foo: 1 }), 'Object.create(null,{foo:{writable:true,value:1}})');
+
 		// let arr = [];
 		// arr.x = 42;
 		// test('Array with named properties', arr, `TODO`);


### PR DESCRIPTION
Resolves https://github.com/Rich-Harris/devalue/issues/16

Removes use of Object.assign in favour of the second parameter of Object.create. This is supported by IE11.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create#Using_propertiesObject_argument_with_Object.create()

Also added a test for this case.