### PR TITLE
Make deserialization more explicit in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ devalue(obj); // '{a:1,b:2,c:3}'
 
 obj.self = obj;
 devalue(obj); // '(function(a){a.a=1;a.b=2;a.c=3;a.self=a;return a}({}))'
+
+// Deserialize into new object
+let newObject = (0, eval)("(" + devalue(obj) + ")");
 ```
 
 ## Error handling


### PR DESCRIPTION
It took me way too long to figure out how to deserialize the string provided by the devalue(). It should be more explicit in the usage example. 