### PR TITLE
fix: handle custom classes with null proto as pojo

### DIFF
--- a/.changeset/sweet-jeans-check.md
+++ b/.changeset/sweet-jeans-check.md
@@ -1,0 +1,5 @@
+---
+"devalue": patch
+---
+
+fix: handle custom classes with null proto as pojo

--- a/src/utils.js
+++ b/src/utils.js
@@ -41,6 +41,7 @@ export function is_plain_object(thing) {
 	return (
 		proto === Object.prototype ||
 		proto === null ||
+		Object.getPrototypeOf(proto) === null ||
 		Object.getOwnPropertyNames(proto).sort().join('\0') === object_proto_names
 	);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,12 @@ class Custom {
 	}
 }
 
+const NullObject = (() => {
+  const C = function () {};
+  C.prototype = Object.create(null);
+  return C;
+})()
+
 const node_version = +process.versions.node.split('.')[0];
 
 const fixtures = {
@@ -319,6 +325,21 @@ const fixtures = {
 				}
 			};
 		})(Object.create(null)),
+
+		((obj) => {
+			obj.self = obj;
+			return {
+				name: 'Object with null prototype class',
+				value: obj,
+				js: '(function(a){a.foo="bar";a.self=a;return a}({}))',
+				json: '[{"foo":1,"self":0},"bar"]',
+				validate: (value) => {
+					assert.is(value.foo, "bar")
+					assert.is(value.self, value);
+
+				}
+			};
+		})(Object.assign(new NullObject(), { foo: 'bar' })),
 
 		((first, second) => {
 			first.second = second;


### PR DESCRIPTION
There is a common pattern that libraries like [ufo](https://github.com/unjs/ufo/blob/5b87427f05d0f34f484b1c9559175d65573b8e1c/src/query.ts#L21-L25) and [cookie](https://github.com/jshttp/cookie/blob/2a1a4d8b2679b208f354e848e711dc8471fb83af/src/index.ts#L68-L72) use to have a custom class with `null` prototype instead of `Object.create(null)` to improve (v8) [performance](https://jsbenchmark.com/#eyJjYXNlcyI6W3siaWQiOiJQdEZfRWZzQzFVWjRaTXBTU1BWTG4iLCJjb2RlIjoiQXJyYXkuZnJvbSh7bGVuZ3RoOiAxMDAwMH0sICgpID0-IG5ldyBEQVRBLkVtcHR5T2JqZWN0KCkpIiwibmFtZSI6IkVtcHR5T2JqZWN0IiwiZGVwZW5kZW5jaWVzIjpbXX0seyJpZCI6Ink4ZHkxeS1ENV8xV3lDeUFRaEJZNyIsImNvZGUiOiJBcnJheS5mcm9tKHtsZW5ndGg6IDEwMDAwfSwgKCkgPT4gREFUQS5PYmplY3RDcmVhdGUoKSkiLCJuYW1lIjoiT2JqZWN0Q3JlYXRlIiwiZGVwZW5kZW5jaWVzIjpbXX1dLCJjb25maWciOnsibmFtZSI6IkJhc2ljIGV4YW1wbGUiLCJwYXJhbGxlbCI6dHJ1ZSwiZ2xvYmFsVGVzdENvbmZpZyI6eyJkZXBlbmRlbmNpZXMiOltdfSwiZGF0YUNvZGUiOiJjb25zdCBFbXB0eU9iamVjdCA9IC8qIEBfX1BVUkVfXyAqLyAoKCkgPT4ge1xuICBjb25zdCBDID0gZnVuY3Rpb24gKCkge307XG4gIEMucHJvdG90eXBlID0gT2JqZWN0LmNyZWF0ZShudWxsKTtcbiAgcmV0dXJuIEM7XG59KSgpO1xuXG5yZXR1cm4geyBFbXB0eU9iamVjdCwgT2JqZWN0Q3JlYXRlOiAoKSA9PiBPYmplY3QuY3JlYXRlKG51bGwpIH0ifX0).

This PR fixes the devalue behavior to support this pattern.

Since there is no obvious way to distinguish `{}` and `new NullProto()` (both have prototype of `[Object: null prototype]`), they are serialized as normal object (with prop oveerrides) 