### PR TITLE
fix: handle repeated array buffers and subarrays

### DIFF
--- a/.changeset/afraid-rats-sit.md
+++ b/.changeset/afraid-rats-sit.md
@@ -1,0 +1,5 @@
+---
+'devalue': patch
+---
+
+fix: handle repeated array buffers and subarrays

--- a/src/parse.js
+++ b/src/parse.js
@@ -115,7 +115,11 @@ export function unflatten(parsed, revivers) {
 					case 'BigUint64Array': {
 						const TypedArrayConstructor = globalThis[type];
 						const typedArray = new TypedArrayConstructor(hydrate(value[1]));
-						hydrated[index] = typedArray;
+
+						hydrated[index] =
+							value[2] !== undefined
+								? typedArray.subarray(value[2], value[3])
+								: typedArray;
 
 						break;
 					}

--- a/src/parse.js
+++ b/src/parse.js
@@ -102,31 +102,30 @@ export function unflatten(parsed, revivers) {
 						}
 						break;
 
-          case "Int8Array":
-          case "Uint8Array":
-          case "Uint8ClampedArray":
-          case "Int16Array":
-          case "Uint16Array":
-          case "Int32Array":
-          case "Uint32Array":
-          case "Float32Array":
-          case "Float64Array":
-          case "BigInt64Array":
-          case "BigUint64Array": {
-            const TypedArrayConstructor = globalThis[type];
-            const base64 = value[1];
-            const arraybuffer = decode64(base64);
-            const typedArray = new TypedArrayConstructor(arraybuffer);
-            hydrated[index] = typedArray;
-            break;
-          }
+					case 'Int8Array':
+					case 'Uint8Array':
+					case 'Uint8ClampedArray':
+					case 'Int16Array':
+					case 'Uint16Array':
+					case 'Int32Array':
+					case 'Uint32Array':
+					case 'Float32Array':
+					case 'Float64Array':
+					case 'BigInt64Array':
+					case 'BigUint64Array': {
+						const TypedArrayConstructor = globalThis[type];
+						const typedArray = new TypedArrayConstructor(hydrate(value[1]));
+						hydrated[index] = typedArray;
 
-          case "ArrayBuffer": {
-            const base64 = value[1];
-            const arraybuffer = decode64(base64);
-            hydrated[index] = arraybuffer;
-            break;
-          }
+						break;
+					}
+
+					case 'ArrayBuffer': {
+						const base64 = value[1];
+						const arraybuffer = decode64(base64);
+						hydrated[index] = arraybuffer;
+						break;
+					}
 
 					default:
 						throw new Error(`Unknown type ${type}`);

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -153,7 +153,18 @@ export function stringify(value, reducers) {
 				case 'BigUint64Array': {
 					/** @type {import("./types.js").TypedArray} */
 					const typedArray = thing;
-					str = '["' + type + '",' + flatten(typedArray.buffer) + ']';
+					str = '["' + type + '",' + flatten(typedArray.buffer);
+
+					const a = thing.byteOffset;
+					const b = a + thing.byteLength;
+
+					// handle subarrays
+					if (a > 0 || b !== typedArray.buffer.byteLength) {
+						const m = +/(\d+)/.exec(type)[1] / 8;
+						str += `,${a / m},${b / m}`;
+					}
+
+					str += ']';
 					break;
 				}
 

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -140,33 +140,32 @@ export function stringify(value, reducers) {
 					str += ']';
 					break;
 
-				case "Int8Array":
-				case "Uint8Array":
-				case "Uint8ClampedArray":
-				case "Int16Array":
-				case "Uint16Array":
-				case "Int32Array":
-				case "Uint32Array":
-				case "Float32Array":
-				case "Float64Array":
-				case "BigInt64Array":
-				case "BigUint64Array": {
+				case 'Int8Array':
+				case 'Uint8Array':
+				case 'Uint8ClampedArray':
+				case 'Int16Array':
+				case 'Uint16Array':
+				case 'Int32Array':
+				case 'Uint32Array':
+				case 'Float32Array':
+				case 'Float64Array':
+				case 'BigInt64Array':
+				case 'BigUint64Array': {
 					/** @type {import("./types.js").TypedArray} */
 					const typedArray = thing;
-					const base64 = encode64(typedArray.buffer);
-					str = '["' + type + '","' + base64 + '"]';
+					str = '["' + type + '",' + flatten(typedArray.buffer) + ']';
 					break;
 				}
-					
-				case "ArrayBuffer": {
+
+				case 'ArrayBuffer': {
 					/** @type {ArrayBuffer} */
 					const arraybuffer = thing;
 					const base64 = encode64(arraybuffer);
-					
+
 					str = `["ArrayBuffer","${base64}"]`;
 					break;
 				}
-				
+
 				default:
 					if (!is_plain_object(thing)) {
 						throw new DevalueError(

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -82,21 +82,22 @@ export function uneval(value, replacer) {
 						keys.pop();
 					}
 					break;
-				
-				case "Int8Array":
-				case "Uint8Array":
-				case "Uint8ClampedArray":
-				case "Int16Array":
-				case "Uint16Array":
-				case "Int32Array":
-				case "Uint32Array":
-				case "Float32Array":
-				case "Float64Array":
-				case "BigInt64Array":
-				case "BigUint64Array":
+
+				case 'Int8Array':
+				case 'Uint8Array':
+				case 'Uint8ClampedArray':
+				case 'Int16Array':
+				case 'Uint16Array':
+				case 'Int32Array':
+				case 'Uint32Array':
+				case 'Float32Array':
+				case 'Float64Array':
+				case 'BigInt64Array':
+				case 'BigUint64Array':
+					walk(thing.buffer);
 					return;
-				
-				case "ArrayBuffer":
+
+				case 'ArrayBuffer':
 					return;
 
 				default:
@@ -177,24 +178,28 @@ export function uneval(value, replacer) {
 			case 'Set':
 			case 'Map':
 				return `new ${type}([${Array.from(thing).map(stringify).join(',')}])`;
-			
-			case "Int8Array":
-			case "Uint8Array":
-			case "Uint8ClampedArray":
-			case "Int16Array":
-			case "Uint16Array":
-			case "Int32Array":
-			case "Uint32Array":
-			case "Float32Array":
-			case "Float64Array":
-			case "BigInt64Array":
-			case "BigUint64Array": {
-				/** @type {import("./types.js").TypedArray} */
-				const typedArray = thing;
-				return `new ${type}([${typedArray.toString()}])`;
+
+			case 'Int8Array':
+			case 'Uint8Array':
+			case 'Uint8ClampedArray':
+			case 'Int16Array':
+			case 'Uint16Array':
+			case 'Int32Array':
+			case 'Uint32Array':
+			case 'Float32Array':
+			case 'Float64Array':
+			case 'BigInt64Array':
+			case 'BigUint64Array': {
+				if (counts.get(thing.buffer) === 1) {
+					/** @type {import("./types.js").TypedArray} */
+					const typedArray = thing;
+					return `new ${type}([${typedArray.toString()}])`;
+				}
+
+				return `new ${type}([${stringify(thing.buffer)}])`;
 			}
-				
-			case "ArrayBuffer": {
+
+			case 'ArrayBuffer': {
 				const ui8 = new Uint8Array(thing);
 				return `new Uint8Array([${ui8.toString()}]).buffer`;
 			}
@@ -278,6 +283,12 @@ export function uneval(value, replacer) {
 						`${name}.${Array.from(thing)
 							.map(([k, v]) => `set(${stringify(k)}, ${stringify(v)})`)
 							.join('.')}`
+					);
+					break;
+
+				case 'ArrayBuffer':
+					values.push(
+						`new Uint8Array([${new Uint8Array(thing).join(',')}]).buffer`
 					);
 					break;
 

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -190,13 +190,25 @@ export function uneval(value, replacer) {
 			case 'Float64Array':
 			case 'BigInt64Array':
 			case 'BigUint64Array': {
+				let str = `new ${type}`;
+
 				if (counts.get(thing.buffer) === 1) {
-					/** @type {import("./types.js").TypedArray} */
-					const typedArray = thing;
-					return `new ${type}([${typedArray.toString()}])`;
+					const array = new thing.constructor(thing.buffer);
+					str += `([${array}])`;
+				} else {
+					str += `([${stringify(thing.buffer)}])`;
 				}
 
-				return `new ${type}([${stringify(thing.buffer)}])`;
+				const a = thing.byteOffset;
+				const b = a + thing.byteLength;
+
+				// handle subarrays
+				if (a > 0 || b !== thing.buffer.byteLength) {
+					const m = +/(\d+)/.exec(type)[1] / 8;
+					str += `.subarray(${a / m},${b / m})`;
+				}
+
+				return str;
 			}
 
 			case 'ArrayBuffer': {

--- a/test/test.js
+++ b/test/test.js
@@ -170,7 +170,7 @@ const fixtures = {
 			name: 'Uint8Array',
 			value: new Uint8Array([1, 2, 3]),
 			js: 'new Uint8Array([1,2,3])',
-			json: '[["Uint8Array","AQID"]]'
+			json: '[["Uint8Array",1],["ArrayBuffer","AQID"]]'
 		},
 		{
 			name: 'ArrayBuffer',
@@ -378,7 +378,26 @@ const fixtures = {
 				js: '(function(a){return [a,a]}({}))',
 				json: '[[1,1],{}]'
 			};
-		})({})
+		})({}),
+
+		{
+			name: 'Array buffer (repetition)',
+			value: (() => {
+				const uint8 = new Uint8Array(10);
+				const uint16 = new Uint16Array(uint8.buffer);
+
+				for (let i = 0; i < uint8.length; i += 1) {
+					uint8[i] = i;
+				}
+
+				return [uint8, uint16];
+			})(),
+			js: '(function(a){return [new Uint8Array([a]),new Uint16Array([a])]}(new Uint8Array([0,1,2,3,4,5,6,7,8,9]).buffer))',
+			json: '[[1,3],["Uint8Array",2],["ArrayBuffer","AAECAwQFBgcICQ=="],["Uint16Array",2]]',
+			validate: ([uint8, uint16]) => {
+				return uint8.buffer === uint16.buffer;
+			}
+		}
 	],
 
 	XSS: [

--- a/test/test.js
+++ b/test/test.js
@@ -177,6 +177,12 @@ const fixtures = {
 			value: new Uint8Array([1, 2, 3]).buffer,
 			js: 'new Uint8Array([1,2,3]).buffer',
 			json: '[["ArrayBuffer","AQID"]]'
+		},
+		{
+			name: 'Sliced typed array',
+			value: new Uint16Array([10, 20, 30, 40]).subarray(1, 3),
+			js: 'new Uint16Array([10,20,30,40]).subarray(1,3)',
+			json: '[["Uint16Array",1,1,3],["ArrayBuffer","CgAUAB4AKAA="]]'
 		}
 	],
 


### PR DESCRIPTION
If an array buffer backs multiple views, it should only be serialized once. This fixes that, and also handles subarrays (note that it does _not_ slice the array buffer — the full data is included. If only a portion of the array buffer is intended to be serialized, it should be sliced beforehand)