### PR TITLE
perf: shrink `uneval` output with null-proto objects

### DIFF
--- a/.changeset/happy-hoops-thank.md
+++ b/.changeset/happy-hoops-thank.md
@@ -1,0 +1,5 @@
+---
+"devalue": patch
+---
+
+perf: shrink `uneval` output with null-proto objects

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -245,17 +245,18 @@ export function uneval(value, replacer) {
 				return `${type}.from(${stringify_string(thing.toString())})`;
 
 			default:
-				const obj = `{${Object.keys(thing)
+				const keys = Object.keys(thing);
+				const obj = keys
 					.map((key) => `${safe_key(key)}:${stringify(thing[key])}`)
-					.join(',')}}`;
+					.join(',');
 				const proto = Object.getPrototypeOf(thing);
 				if (proto === null) {
-					return Object.keys(thing).length > 0
-						? `Object.assign(Object.create(null),${obj})`
-						: `Object.create(null)`;
+					return keys.length > 0
+						? `{${obj},__proto__:null}`
+						: `{__proto__:null}`;
 				}
 
-				return obj;
+				return `{${obj}}`;
 		}
 	}
 

--- a/test/test.js
+++ b/test/test.js
@@ -516,7 +516,7 @@ const fixtures = {
 		{
 			name: 'Object without prototype',
 			value: Object.create(null),
-			js: 'Object.create(null)',
+			js: '{__proto__:null}',
 			json: '[["null"]]',
 			validate: (value) => {
 				assert.equal(Object.getPrototypeOf(value), null);


### PR DESCRIPTION
This shrinks the output of `uneval` when using null-prototyped objects. If an empty object is used, the size of `uneval` decreases by 3 characters per object, and if the object has properties, the size decreases by 20 characters per object:
```diff
-Object.create(null);
+{__proto__:null}
```
```diff
-Object.assign(Object.create(null),{thing:true});
+{thing:true,__proto__:null}
```