### PR TITLE
fix: emit valid JS for Node `Buffer` in `uneval`

### DIFF
--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+'devalue': patch
+---
+
+fix: emit valid JS for Node `Buffer` in `uneval`

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -290,7 +290,7 @@ export function uneval(value, replacer) {
 				let str = `new ${type}`;
 
 				if (!names.has(thing.buffer)) {
-					str += `([${stringify_typed_array_elements(new thing.constructor(thing.buffer))}])`;
+					str += `([${stringify_typed_array_elements(type, thing.buffer)}])`;
 				} else {
 					str += `(${stringify(thing.buffer)})`;
 				}
@@ -451,7 +451,7 @@ export function uneval(value, replacer) {
 					let str = `new ${type}`;
 
 					if (!names.has(thing.buffer)) {
-						str += `([${stringify_typed_array_elements(new thing.constructor(thing.buffer))}])`;
+						str += `([${stringify_typed_array_elements(type, thing.buffer)}])`;
 					} else {
 						str += `(${stringify(thing.buffer)})`;
 					}
@@ -522,13 +522,19 @@ export function uneval(value, replacer) {
 }
 
 /**
- * Serialize the elements of a typed array as a comma-separated list.
+ * Serialize the elements of `buffer`, read as `type`, as a comma-separated list.
+ * The view is created from `type` rather than from the serialized value's own
+ * constructor, which may be a subclass like Node's `Buffer` whose `toString`
+ * decodes the bytes instead of listing them.
  * `BigInt64Array`/`BigUint64Array` elements are bigints and must be written
  * with an `n` suffix, otherwise the emitted `new BigInt64Array([...])` throws.
- * @param {import('./types.js').TypedArray} array
+ * @param {string} type
+ * @param {ArrayBufferLike} buffer
  */
-function stringify_typed_array_elements(array) {
-	if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+function stringify_typed_array_elements(type, buffer) {
+	const array = new (/** @type {any} */ (globalThis)[type])(buffer);
+
+	if (type === 'BigInt64Array' || type === 'BigUint64Array') {
 		return Array.from(array, (element) => `${element}n`).join(',');
 	}
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -300,6 +300,15 @@ const fixtures = {
 			json: '[["Uint8Array",1],["ArrayBuffer","AQID"]]'
 		},
 		{
+			// `Buffer.alloc` does not allocate from Node's shared pool, so the buffer
+			// backing this view is exactly four bytes and the expectations are stable
+			name: 'Node Buffer',
+			value: Buffer.alloc(4, 65),
+			js: 'new Uint8Array([65,65,65,65])',
+			json: '[["Uint8Array",1],["ArrayBuffer","QUFBQQ=="]]',
+			validate: (value) => assert.equal(value, new Uint8Array([65, 65, 65, 65]))
+		},
+		{
 			name: 'BigInt64Array',
 			value: new BigInt64Array([1n, -2n, 3n]),
 			js: 'new BigInt64Array([1n,-2n,3n])',


### PR DESCRIPTION
`uneval(Buffer.alloc(4, 65))` returns `new Uint8Array([AAAA])`, because the element list is built from the value's own constructor and `Buffer.prototype.toString` decodes the bytes instead of listing them. Same shape as #171.

Reported downstream as sveltejs/kit#16603.