### PR TITLE
fix: uneval emits valid JS for graphs with more than 65534 repeated references

### DIFF
--- a/.changeset/fix-uneval-param-limit.md
+++ b/.changeset/fix-uneval-param-limit.md
@@ -1,0 +1,5 @@
+---
+"devalue": patch
+---
+
+fix: `uneval` emits valid JS for graphs with more than 65534 repeated references

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -515,6 +515,14 @@ export function uneval(value, replacer) {
 		statements.push(`return ${str}`);
 
 		const body = [...reconstructions, ...statements].join(';');
+		// A function may have at most 65535 parameters (and a call at most that
+		// many arguments). For very large graphs, pass the hoisted values as a
+		// single array argument and destructure them into the placeholder names,
+		// so the emitted code stays within the engine limit (#93).
+		if (params.length > 65534) {
+			return `(function(){var[${params.join(',')}]=arguments[0];${body}}([${values.join(',')}]))`;
+		}
+
 		return `(function(${params.join(',')}){${body}}(${values.join(',')}))`;
 	} else {
 		return str;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1909,3 +1909,27 @@ circularCustomTypes('resolves self-referencing custom type', () => {
 });
 
 circularCustomTypes.run();
+
+
+{
+	const test = uvu.suite('uneval: large graphs');
+
+	test('serializes more than 65534 repeated references to valid JS', () => {
+		// A function may have at most 65535 parameters, so one hoisted parameter
+		// per repeated value produced code the engine rejects with "Too many
+		// parameters in function definition". See issue #93.
+		const shared = Array.from({ length: 70000 }, (_, i) => ({ i }));
+		const value = { a: shared, b: shared.slice() };
+
+		const serialized = uneval(value);
+		const roundtripped = new Function('return ' + serialized)();
+
+		assert.equal(roundtripped.a.length, 70000);
+		assert.equal(roundtripped.a[0].i, 0);
+		assert.equal(roundtripped.a[69999].i, 69999);
+		// the two arrays share object identity
+		assert.ok(roundtripped.a[123] === roundtripped.b[123]);
+	});
+
+	test.run();
+}


### PR DESCRIPTION
Fixes #93.

`uneval` hoists every value referenced more than once into a parameter of a single IIFE (`(function(a,b,c){...}(1,2,3))`). A function may have at most 65535 parameters, so a graph with more than ~65534 repeated references produces code that engines reject:

```
SyntaxError: Too many parameters in function definition (only 65534 allowed)
```

Repro:

```js
const shared = Array.from({ length: 70000 }, () => ({}));
uneval({ a: shared, b: shared.slice() }); // the output throws when eval'd
```

**Fix:** when the parameter count exceeds the limit, pass the hoisted values as a single array argument and destructure them into the placeholder names:

```js
(function(){var[a,b,c]=arguments[0];...}([1,2,3]))
```

instead of one parameter each. This also avoids the analogous too-many-arguments limit on the call. Graphs below the threshold are byte-for-byte unchanged.

**Test:** added a case that uneval-serializes a graph with 70,000 repeated references and `eval`s the output, asserting the round-trip and shared identity. Verified red before the fix (`Too many parameters in function definition`) and green after. `npm test` (uvu) passes: 723 + 29 + 18.

---

Disclosure: developed with the assistance of Claude Code (AI); reviewed and verified by me.
