### PR TITLE
fix: preserve -0 in float typed arrays in uneval

### DIFF
--- a/.changeset/uneval-float-negative-zero.md
+++ b/.changeset/uneval-float-negative-zero.md
@@ -1,0 +1,5 @@
+---
+'devalue': patch
+---
+
+fix: preserve `-0` in float typed arrays in `uneval`

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -532,6 +532,16 @@ function stringify_typed_array_elements(array) {
 		return Array.from(array, (element) => `${element}n`).join(',');
 	}
 
+	// Float arrays can hold `-0`, which `toString()` collapses to `"0"`, silently
+	// losing the sign on round-trip. Emit `-0` explicitly for those elements.
+	if (
+		array instanceof Float32Array ||
+		array instanceof Float64Array ||
+		(typeof Float16Array !== 'undefined' && array instanceof Float16Array)
+	) {
+		return Array.from(array, (element) => (Object.is(element, -0) ? '-0' : `${element}`)).join(',');
+	}
+
 	return array.toString();
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -300,6 +300,16 @@ const fixtures = {
 			json: '[["Uint8Array",1],["ArrayBuffer","AQID"]]'
 		},
 		{
+			name: 'Float64Array with negative zero',
+			value: new Float64Array([-0, 1.5]),
+			js: 'new Float64Array([-0,1.5])',
+			json: '[["Float64Array",1],["ArrayBuffer","AAAAAAAAAIAAAAAAAAD4Pw=="]]',
+			validate: (value) => {
+				assert.ok(Object.is(value[0], -0));
+				assert.equal(value[1], 1.5);
+			}
+		},
+		{
 			name: 'BigInt64Array',
 			value: new BigInt64Array([1n, -2n, 3n]),
 			js: 'new BigInt64Array([1n,-2n,3n])',


### PR DESCRIPTION
Bug — `uneval` loses the sign of `-0` in float typed arrays:

```js
uneval(new Float64Array([-0])); // "new Float64Array([0])" -> round-trips to +0
stringify(new Float64Array([-0])); // preserves -0
```

Cause: `stringify_typed_array_elements` serializes non-BigInt typed-array elements with `Array.prototype.toString`, which renders `-0` as `"0"`. `stringify` is unaffected because it base64-encodes the raw buffer, so the two serializers disagree and only `uneval` drops the sign bit.

Fix: for `Float32Array`/`Float64Array`/`Float16Array`, map elements and emit `-0` explicitly (via `Object.is`); integer arrays keep the fast `toString` path. `Float16Array` is `typeof`-guarded so nothing throws on Node without it.

Evidence: added a `Float64Array([-0, 1.5])` fixture (fails before, passes after); full suite 797/797, `build` + `publint` clean.
